### PR TITLE
Get the test_bayes tests into a working state.

### DIFF
--- a/tests/unit/test_plugins/test_bayes.py
+++ b/tests/unit/test_plugins/test_bayes.py
@@ -1,20 +1,18 @@
 """Tests for the Bayes plug-in."""
 
-import email
-import hashlib
 import unittest
 
 import mock
 from mock import MagicMock
-
-from oa.plugins.bayes import BayesPlugin
+from oa.plugins.bayes import BayesPlugin, Store
+from oa.message import Message
 
 
 class BayesTests(unittest.TestCase):
     """Test cases for the BayesPlugin class."""
 
     def setUp(self):
-        self.global_data = {}
+        self.global_data = {"use_bayes": True}
         self.mock_ctxt = MagicMock(**{
             "get_plugin_data.side_effect": lambda p, k: self.global_data[k],
             "set_plugin_data.side_effect": lambda p, k, v: self.global_data.setdefault(k, v)})
@@ -24,59 +22,33 @@ class BayesTests(unittest.TestCase):
             "password":"",
             "db_name":"",
         }
-        mock.patch("pad.plugins.bayes.BayesPlugin.get_engine", return_value=engine).start()
+        mock.patch("oa.plugins.bayes.BayesPlugin.get_engine", return_value=engine).start()
 
     def tearDown(self):
         mock.patch.stopall()
 
-
-    def test_get_msgid(self):
-        """Test the get_msgid method when there is a Message-ID header."""
-        msg_id = "test-id"
-        msg = email.message_from_string("Message-ID: <%s>\n\nTest" % msg_id)
-        found_id = BayesPlugin(self.mock_ctxt).get_msgid(msg)
-        self.assertEqual(msg_id, found_id)
-
-    def test_get_msgid_generated(self):
-        """Test the get_msgid method when there is no Message-ID header."""
-        text = "Hello world!"
-        msg = email.message_from_string("Subject: test\n\n%s" % text)
-        found_id = BayesPlugin(self.mock_ctxt).get_msgid(msg)
-        combined = "None\x00%s" % text
-        msg_id = "%s@sa_generated" % hashlib.sha1(combined.encode('utf-8')).hexdigest()
-        self.assertEqual(msg_id, found_id)
-
     def test_learn_message(self):
         """Test the learn_message method."""
-        msgdata = {}
         b = BayesPlugin(self.mock_ctxt)
-        b.get_body_from_msg = lambda x: msgdata
+        b.get_body_from_msg = lambda x: {}
+        b.store = Store(b)
         b.store.tie_db_writeable = lambda: True
         ret = "test"
-        msg = "test message"
+        msg = Message(self.mock_ctxt, "test message")
         isspam = True
         b._learn_trapped = mock.MagicMock(return_value=ret)
         b.learn_caller_will_untie = True
         result = b.learn_message(msg, isspam)
         self.assertEqual(ret, result)
-        b._learn_trapped.assert_called_once_with(isspam, msg, msgdata, None)
+        b._learn_trapped.assert_called_once_with(isspam, msg)
 
     def test_learn_message_no_bayes(self):
         """Test the learn_message method when bayes is not enabled."""
         b = BayesPlugin(self.mock_ctxt)
-        b["use_bayes"] = False
+        b.store = Store(b)
+        self.global_data["use_bayes"] = False
         result = b.learn_message(None, None)
         self.assertEqual(result, None)
-
-    def test_receive_date(self):
-        """Test the receive_date method."""
-        msg = email.message_from_string("""Received: from server6.seinternal.com ([178.63.74.9])
- by mx99.antispamcloud.com with esmtps (TLSv1.2:DHE-RSA-AES128-SHA:128)
- (Exim 4.85) id 1azjrM-000RwX-P5
- for spam@mx99.antispamcloud.com; Mon, 09 May 2016 14:00:25 +0200\n\nHello world!""")
-        expected = 1462795225
-        result = BayesPlugin(self.mock_ctxt).receive_date(msg)
-        self.assertEqual(expected, result)
 
 
 def suite():
@@ -84,6 +56,7 @@ def suite():
     test_suite = unittest.TestSuite()
     test_suite.addTest(unittest.makeSuite(BayesTests, "test"))
     return test_suite
+
 
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')


### PR DESCRIPTION
It seems the test_bayes tests has not worked for a long time. This
diff makes the test run on my machine with the following changes:
* Removed the msgid and receive_date tests, as the code they are
testing moved to oa/message.py. The tests are submitted in updated
form in https://github.com/SpamExperts/OrangeAssassin/pull/83
* Updated learn_message test to the new call signature of
_learn_trapped
* Have the setUp get_engine() reflect the module remname pad -> oa