### PR TITLE
an attempt to have test_daemon be more stable on pypy

### DIFF
--- a/tests/functional/test_daemon.py
+++ b/tests/functional/test_daemon.py
@@ -144,7 +144,7 @@ class TestDaemonBase(unittest.TestCase):
             # for more time. This is only ran once so the impact
             # is minimal anyway.
             # This should prevent random test failures on PyPy.
-            sleep_time = 2.0
+            sleep_time = 10.0
         time.sleep(sleep_time)
 
     @classmethod


### PR DESCRIPTION
The `functional/test_daemon.py` tests were failing pretty consistently on pypy3. Increasing the sleep before trying to connect to the daemon just started seems to resolve the issue.