### PR TITLE
Fix minor bugs and usability issues with the bayes plugin

### DIFF
--- a/oa/plugins/bayes.py
+++ b/oa/plugins/bayes.py
@@ -675,7 +675,7 @@ class BayesPlugin(oa.plugins.base.BasePlugin):
         # a safety measure.
         if msgatime - time.time() > 86400:
             msgatime = time.time()
-        tokens = self.tokenise(msg)
+        tokens = (t[1] for t in self.tokenise(msg))
         # XXX SA puts this in a timer.
         if isspam:
             self.store.nspam_nham_change(1, 0)

--- a/tests/unit/test_plugins/test_bayes.py
+++ b/tests/unit/test_plugins/test_bayes.py
@@ -3,21 +3,44 @@
 import email
 import hashlib
 import unittest
+from tempfile import NamedTemporaryFile
 
 import mock
 from mock import MagicMock
 
-from oa.plugins.bayes import BayesPlugin
+from oa.plugins.bayes import BayesPlugin, Store
+
+
+def _make_mock_context(presets):
+    """
+    Construct a context mock instance that implements get_plugin_data() and
+    set_plugin_data() with a simple global backing dict and the quirk that
+    get_plugin_data() will return a value from the preset dict if the
+    corresponding key exists there.
+    """
+    backing = {}
+    ctx = MagicMock()
+
+    def _get_plugin_effect(_, key):
+        if key in presets:
+            return presets[key]
+        return backing[key]
+
+    ctx.get_plugin_data.side_effect = _get_plugin_effect
+
+    def _set_plugin_effect(_, key, value):
+        backing[key] = value
+
+    ctx.set_plugin_data.side_effect = _set_plugin_effect
+    return ctx
 
 
 class BayesTests(unittest.TestCase):
     """Test cases for the BayesPlugin class."""
 
     def setUp(self):
-        self.global_data = {}
-        self.mock_ctxt = MagicMock(**{
-            "get_plugin_data.side_effect": lambda p, k: self.global_data[k],
-            "set_plugin_data.side_effect": lambda p, k, v: self.global_data.setdefault(k, v)})
+        self.global_data = {"use_bayes": True}
+        self.mock_ctxt = _make_mock_context(self.global_data)
         engine = {
             "hostname":"",
             "user":"",
@@ -77,6 +100,19 @@ class BayesTests(unittest.TestCase):
         expected = 1462795225
         result = BayesPlugin(self.mock_ctxt).receive_date(msg)
         self.assertEqual(expected, result)
+
+
+class BayesDatabaseTest(unittest.TestCase):
+    def test_empty_database(self):
+        temp_file = NamedTemporaryFile()
+        backing = {"bayes_sql_dsn": "sqlite:///{}".format(temp_file.name)}
+        ctx = _make_mock_context(backing)
+        b = BayesPlugin(ctx)
+        b.finish_parsing_end(None)
+
+        store = Store(b)
+        store.tie_db_writeable()
+        self.assertIsNone(store.seen_get("non-existent-id"))
 
 
 def suite():


### PR DESCRIPTION
* Introduce a metadata database table in the sqlalchemy Store for
  the bayes plugin, so that we can keep track of whether the database
  schema exists and is the right version. This enables the plugin to
  start with an empty file as a database.
* Fix bug in seen_get() where attempting to get a flag from a message
  not yet seen would raise an exception
* Fix a bug where multi_tok_count_change() expects an iterable of tokens
  but gets an iterable of tuples
* Introduce a test case that verifies that seen_get() return None with
  an empty database (also verifies the schema creation functionality)