### PR TITLE
fix(python3): can't install py3dns==3.1.0

### DIFF
--- a/requirements/python3.txt
+++ b/requirements/python3.txt
@@ -1,2 +1,2 @@
 dnspython3==1.12.0
-py3dns==3.1.0
+py3dns==3.2.0


### PR DESCRIPTION
The 3.1.0 version of py3dns can't be installed, see https://bugs.launchpad.net/py3dns/+bug/1776027
There's a syntax error, that was fixed in 3.2.0.